### PR TITLE
Moved "publish" string

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -450,7 +450,7 @@
         message.attraction_bonus = Math.round(response.user.trap_attraction_bonus*100);
 
         // Caught / Attracted / Mouse
-        var outcome = journal.publish_data.attachment.name;
+        var outcome = journal.render_data.text;
         if (outcome.indexOf('I caught') !== -1) {
             message.caught = 1;
             message.attracted = 1;


### PR DESCRIPTION
It looks like this is the only thing that actually moved. I don't know how to test it. The referenced item appears to refer to what is now the render_data.text in the journal entry and looks like the text one would see in the journal itself.

FWIW the journal.render.css_class contains "entry short active catchsuccessloot" for when I caught a mouse and got loot. Since nobody ever changes css class names those could be safe to check for catch/FTC/FTA - and whether to check for loot.