### PR TITLE
Fix bug where ` mouse` was not matched

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -452,13 +452,13 @@
             message.attracted = 1;
             message.mouse = outcome.replace(/^(.*?)\">/, '');
             message.mouse = message.mouse.replace(/\<\/a\>.*/i, '');
-            message.mouse = message.mouse.replace(/(\ mouse)?/i, '');
+            message.mouse = message.mouse.replace(/(\ mouse$)+/i, '');
         } else if (journal.render_data.css_class.indexOf('catchfailure') !== -1) {
             message.caught = 0;
             message.attracted = 1;
             message.mouse = outcome.replace(/^(.*?)\">/, '');
             message.mouse = message.mouse.replace(/\<\/a\>.*/i, '');
-            message.mouse = message.mouse.replace(/(\ mouse)?/i, '');
+            message.mouse = message.mouse.replace(/(\ mouse$)+/i, '');
         } else if (journal.render_data.css_class.indexOf('attractionfailure') !== -1) {
             message.caught = 0;
             message.attracted = 0;


### PR DESCRIPTION
- Requires the ` mouse` text to appear at the end of the input
   - should be safe against future mice with Mouse as a standalone word not at the beginning or end of their name
   - the preceding pattern ensures all text after the `</a>` is removed, so that if the game's name for it does include " Mouse", e.g. "Treasure Keeper Mouse", that the `$` condition is met.