### PR TITLE
Fixed login check alert spam

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -19,7 +19,7 @@
         if (ev.data.jacks_message === null) {
             return;
         }
-        if (typeof user.user_id === 'undefined') {
+        if (typeof user.user_id === 'undefined' && ev.data.indexOf('plugin_ready') > -1) {
             alert('Please make sure you are logged in into MH.');
             return;
         }


### PR DESCRIPTION
The game occasionally logs me out on both desktop & mobile, which causes [this](https://streamable.com/f1mof) to happen. I added a check that should limit the alerts to just 1 (instead of about 7).