### PR TITLE
Track LNY bonus luck via hunt_details

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -668,8 +668,12 @@
 
         // 2019 LNY costumed mice check
         let quest = response.user.quests.QuestLunarNewYear2019;
-        if (quest != null && quest.has_stockpile == "found" && !quest.mice.costumed_pig.includes("caught")) {
-            return "";
+        if (quest && quest.has_stockpile == "found" && !quest.mice.costumed_pig.includes("caught")) {
+            // Ignore event cheese hunts as the player is attracting the Costumed mice in a specific order.
+            let dumpling = quest.items.lunar_new_year_2017_cheese;
+            let nian = quest.items.lunar_new_year_2018_cheese;
+            if (dumpling.status === "active" || nian.status === "active")
+                return "";
         }
 
         return message;
@@ -1269,6 +1273,16 @@
             case "Mysterious Anomaly":
                 message = getMysteriousAnomalyHuntDetails(message, response, journal);
                 break;
+        }
+
+        // Include any bonus luck from an active lantern in the hunt details. (Doubled/tripled loot is added
+        // via a bonus journal entry, thus we do not need to inspect quest.lantern_status for double or triple.)
+        let quest = response.user.quests.QuestLunarNewYear2019;
+        if (quest && quest.is_lantern_active) {
+            // Avoid overwriting any existing details.
+            if (!message.hunt_details)
+                message.hunt_details = {};
+            message.hunt_details.lny_luck = parseInt(quest.luck, 10);
         }
 
         return message;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1464,7 +1464,19 @@
                 luck = null;
             }
         } else if (postHuntHeight > 0) {
-            let preHuntHeight = postHuntHeight - 1;
+            let yellow = lnyQuest.items.lny_unlit_lantern_stat_item;
+            let red = lnyQuest.items.lny_unlit_lantern_2018_stat_item;
+            // Default to an underestimate of the pre-hunt height.
+            let increase = 2;
+            if (yellow.status === "active") {
+                increase = 1;
+            } else if (red.status === "active") {
+                increase = 2;
+            } else if (parseInt(red.quantity, 10) > 0) {
+                // Neither is active, but we still have red candles --> ran out of yellows.
+                increase = 1;
+            }
+            let preHuntHeight = Math.max(0, postHuntHeight - increase);
             luck = Math.min(50, Math.floor(preHuntHeight / 10));
         }
         return luck;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1450,12 +1450,13 @@
      * @returns {number} The amount of luck associated with the given lantern height, or `null` if uncertain.
      */
     function getLNYLuck(lnyQuest) {
-        // TODO: does `lit_lantern` or `lantern_height` keep increasing? Or are they capped at 500?
-        // If one is uncapped, this function can become much simpler.
+        // `lantern_height` is capped at 500, though `lit_lantern` keeps increasing. Red candles
+        // provide a +2 bonus, so we cannot rely solely on `lit_lantern`.
         let postHuntHeight = parseInt(lnyQuest.lantern_height, 10);
         let luck = 0;
         if (postHuntHeight === 500) {
-            if (lnyQuest.rows.row_49 === "claimed" || parseInt(lnyQuest.lit_lantern, 10) > 500) {
+            // If we have claimed the final reward, or lit more than 500 lanterns, we are at max luck.
+            if (lnyQuest.rows.row_49.includes("claimed") || parseInt(lnyQuest.lit_lantern, 10) > 500) {
                 luck = 50;
             } else {
                 // We cannot be sure if this was the hunt from 499 -> 500, or a hunt

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1292,15 +1292,15 @@
                 // Each hunt with the active lantern increases the height by 1, and thus possibly the luck.
                 lny_luck = getLNYLuck(quest);
             } else {
-                // The lantern is inactive. This may be an explicit choice, or because the user ran out of equipped candles.
                 let yellow = quest.items.lny_unlit_lantern_stat_item;
                 let red = quest.items.lny_unlit_lantern_2018_stat_item;
-                // If the user has both candles, we know the lantern state was an explicit
-                // choice. (Candles given via height rewards must be explicitly claimed.)
+                // If the user has both candles, we know the lantern state was an explicit choice.
+                // (Candles given via height rewards must be explicitly claimed.)
                 if (parseInt(yellow.quantity, 10) > 0 && parseInt(red.quantity, 10) > 0) {
                     lny_luck = 0;
-                } else if (yellow.status === "active" || red.status === "active") {
-                    lny_luck = getLNYLuck(quest);
+                } else {
+                    // Without knowledge of the pre-hunt state, we cannot determine if this hunt
+                    // consumed the final candle of a either type, and *that* is why the lantern is disabled.
                 }
             }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1289,7 +1289,6 @@
                 message.hunt_details = {};
             }
             message.hunt_details.is_lny_hunt = true;
-            message.hunt_details.is_valentines_hunt = quest.event_status === "valentines";
 
             let lny_luck = null;
             if (quest.lantern_status.includes("noLantern")) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -674,7 +674,7 @@
 
         // 2019 LNY costumed mice check
         let quest = response.user.quests.QuestLunarNewYear2019;
-        if (quest && quest.has_stockpile == "found" && !quest.mice.costumed_pig.includes("caught")) {
+        if (quest && quest.has_stockpile === "found" && !quest.mice.costumed_pig.includes("caught")) {
             // Ignore event cheese hunts as the player is attracting the Costumed mice in a specific order.
             let dumpling = quest.items.lunar_new_year_2017_cheese;
             let nian = quest.items.lunar_new_year_2018_cheese;
@@ -823,7 +823,7 @@
             message.stage = "Boss";
         } else {
             message.stage = quest.decorations.current_decoration;
-            if (message.stage == "none") {
+            if (message.stage === "none") {
                 message.stage = "No Decor";
             } else {
                 message.stage = message.stage.replace(/_festive_decoration_stat_item/i, '');

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1289,6 +1289,7 @@
                 message.hunt_details = {};
             }
             message.hunt_details.is_lny_hunt = true;
+            message.hunt_details.is_valentines_hunt = quest.event_status === "valentines";
 
             let lny_luck = null;
             if (quest.lantern_status.includes("noLantern")) {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1441,10 +1441,12 @@
      * @returns {number} The amount of luck associated with the given lantern height, or `null` if uncertain.
      */
     function getLNYLuck(lnyQuest) {
+        // TODO: does `lit_lantern` or `lantern_height` keep increasing? Or are they capped at 500?
+        // If one is uncapped, this function can become much simpler.
         let postHuntHeight = parseInt(lnyQuest.lantern_height, 10);
         let luck = 0;
         if (postHuntHeight === 500) {
-            if (quest.rows.row_49 === "claimed") {
+            if (lnyQuest.rows.row_49 === "claimed" || parseInt(lnyQuest.lit_lantern, 10) > 500) {
                 luck = 50;
             } else {
                 // We cannot be sure if this was the hunt from 499 -> 500, or a hunt

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -270,7 +270,13 @@
                 continue;
             }
 
+            // Skip non-hunt entries like bonus loot from items, Enerchi/Unstable charms, Wild Tonic, etc.
             if (journal_render_data.css_class.search(/linked|passive|misc/) !== -1) {
+                // Any notification about the LNY lantern becoming disabled due to running out of candles
+                // precedes the entry for the active hunt. It is not necessarily the first (i===0) entry.
+                if (journal_render_data.text.includes("I will no longer benefit from the magic of the Pig Lunar Lantern!")) {
+                    response.lanternBecameDisabled = true;
+                }
                 continue;
             }
 
@@ -1288,7 +1294,7 @@
             if (quest.lantern_status.includes("noLantern")) {
                 // The user has no pig lantern yet, so they cannot have bonus LNY luck.
                 lny_luck = 0;
-            } else if (quest.is_lantern_active) {
+            } else if (quest.is_lantern_active || response.lanternBecameDisabled) {
                 // Each hunt with the active lantern increases the height by 1, and thus possibly the luck.
                 lny_luck = getLNYLuck(quest);
             } else {
@@ -1299,8 +1305,11 @@
                 if (parseInt(yellow.quantity, 10) > 0 && parseInt(red.quantity, 10) > 0) {
                     lny_luck = 0;
                 } else {
-                    // Without knowledge of the pre-hunt state, we cannot determine if this hunt
-                    // consumed the final candle of a either type, and *that* is why the lantern is disabled.
+                    // Without explicit knowledge of the pre-hunt state, we cannot determine if
+                    // this hunt consumed the final equipped candle of either type. If that had
+                    // indeed occurred, and the "lantern disabled" journal entry was not detected
+                    // properly, assigning `lny_luck = 0` would be an error here. Since there is
+                    // some possible doubt re: the state of lny_luck, leave it unset.
                 }
             }
 


### PR DESCRIPTION
 - Restrict event mice check to only those done with event cheese (since Costumed ____ mice are not attracted to the stockpile's normal bait)
 - Track bonus luck from active lantern as a hunt detail
 - flag all hunts for which a lny quest exists (and thus a bonus luck amount may also exist)