### PR TITLE
Refactor popup.js code

### DIFF
--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,3 +1,10 @@
+// JS script available only within the pop-up html pages (popup.html & popup2.html)
+/**
+ * Query the open tabs and locate the MH tabs. Passes the first result to the callback, along with the invoking button.
+ * @param {string} button_pressed the HTML id of the pressed button, to be forwarded to callback
+ * @param {Function} callback A function that expects the MH page's tab ID and possibly the button that invoked the call
+ * @param {boolean} [silent] if true, errors will not be displayed to the user.
+ */
 function findOpenMHTab(button_pressed, callback, silent) {
     chrome.tabs.query({'url': ['*://www.mousehuntgame.com/*', '*://apps.facebook.com/mousehunt/*']}, tabs => {
         if (tabs.length > 0) {
@@ -9,8 +16,14 @@ function findOpenMHTab(button_pressed, callback, silent) {
     });
 }
 
+/**
+ * Forward the pressed button to the content script on the identified tab.
+ * (Horn button clicks also activate the MH page.)
+ * @param {number} tab_id The tab ID of the MH page
+ * @param {string} button_pressed The HTML element ID of the button that was clicked
+ */
 function sendMessageToScript(tab_id, button_pressed) {
-    // Switch to mh tab
+    // Switch to MH tab if needed.
     if (button_pressed === "horn") {
         chrome.tabs.update(tab_id, {'active': true});
     }
@@ -26,14 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     findOpenMHTab("huntTimer", updateHuntTimer, true);
 
-    let buttons = [
-        'mhmh',
-        'userhistory',
-        'ryonn',
-        'horn',
-        'tsitu_loader'
-    ];
-    buttons.forEach(id => {
+    // Send specific clicks to the content script for handling and/or additional forwarding.
+    ['mhmh', 'userhistory', 'ryonn', 'horn', 'tsitu_loader'].forEach(id => {
         let button_element = document.getElementById(id);
         if (!button_element) {
             return;
@@ -42,6 +49,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+/**
+ * Query the MH page and display the time remaining until the next horn.
+ * @param {number} tab The tab id of the MH page
+ * @param {HTMLElement} [huntTimerField] The div element corresponding to the horn countdown timer.
+ */
 function updateHuntTimerField(tab, huntTimerField) {
     chrome.tabs.sendMessage(tab, {jacks_link: "huntTimer"}, response => {
         if (huntTimerField === null) {
@@ -55,12 +67,21 @@ function updateHuntTimerField(tab, huntTimerField) {
     });
 }
 
+/**
+ * Schedule updates of the hunt timer field every second
+ * @param {number} tab The tab id of the MH page
+ * @param {string} button_pressed The element ID of the associated button that invoked this call
+ */
 function updateHuntTimer(tab, button_pressed) {
     let huntTimerField = document.getElementById("huntTimer");
     updateHuntTimerField(tab, huntTimerField); // Fire now
     setInterval(updateHuntTimerField, 1000, tab, huntTimerField); // Continue firing each second
 }
 
+/**
+ * Display the associated message
+ * @param {string} message The message to display
+ */
 function displayErrorPopup(message) {
     let error_popup = document.getElementById('error_popup');
     error_popup.innerText = message;

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -36,7 +36,7 @@ function sendMessageToScript(tab_id, button_id) {
 document.addEventListener('DOMContentLoaded', () => {
     const version_element = document.getElementById("version");
     if (version_element) {
-        version_element.innerText = ' v' + chrome.runtime.getManifest().version;
+        version_element.innerText = ` v${chrome.runtime.getManifest().version}`;
     }
     // Schedule updates of the horn timer countdown.
     findOpenMHTab(tab => {

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -24,12 +24,13 @@ function findOpenMHTab(button_pressed, callback, silent) {
  */
 function sendMessageToScript(tab_id, button_pressed) {
     // Switch to MH tab if needed.
-    if (button_pressed === "horn") {
+    let needsMHPageActive = ['horn', 'tsitu_loader', 'mhmh', 'ryonn'];
+    if (needsMHPageActive.includes(button_pressed)) {
         chrome.tabs.update(tab_id, {'active': true});
     }
 
     // Send message to content script
-    chrome.tabs.sendMessage(tab_id, {jacks_link: button_pressed}, response => {});
+    chrome.tabs.sendMessage(tab_id, {jacks_link: button_pressed});
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -42,10 +43,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Send specific clicks to the content script for handling and/or additional forwarding.
     ['mhmh', 'userhistory', 'ryonn', 'horn', 'tsitu_loader'].forEach(id => {
         let button_element = document.getElementById(id);
-        if (!button_element) {
-            return;
+        if (button_element) {
+            button_element.addEventListener('click', () => findOpenMHTab(id, sendMessageToScript));
         }
-        button_element.addEventListener('click', () => findOpenMHTab(id, sendMessageToScript));
     });
 });
 

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -24,7 +24,7 @@ function findOpenMHTab(callback, button_id, silent) {
  */
 function sendMessageToScript(tab_id, button_id) {
     // Switch to MH tab if needed.
-    let needsMHPageActive = ['horn', 'tsitu_loader', 'mhmh', 'ryonn'];
+    const needsMHPageActive = ['horn', 'tsitu_loader', 'mhmh', 'ryonn'];
     if (needsMHPageActive.includes(button_id)) {
         chrome.tabs.update(tab_id, {'active': true});
     }
@@ -34,27 +34,27 @@ function sendMessageToScript(tab_id, button_id) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    let version_element = document.getElementById("version");
+    const version_element = document.getElementById("version");
     if (version_element) {
         version_element.innerText = ' v' + chrome.runtime.getManifest().version;
     }
     // Schedule updates of the horn timer countdown.
     findOpenMHTab(tab => {
-        let huntTimerField = document.getElementById("huntTimer");
+        const huntTimerField = document.getElementById("huntTimer");
         updateHuntTimerField(tab, huntTimerField); // Fire now
         setInterval(updateHuntTimerField, 1000, tab, huntTimerField); // Continue firing each second
     }, null, true);
 
     // Send specific clicks to the content script for handling and/or additional forwarding.
     ['mhmh', 'userhistory', 'ryonn', 'horn', 'tsitu_loader'].forEach(id => {
-        let button_element = document.getElementById(id);
+        const button_element = document.getElementById(id);
         if (button_element) {
             button_element.addEventListener('click', () => findOpenMHTab(sendMessageToScript, id));
         }
     });
 
     // Set up the options page listener.
-    let options_button = document.getElementById('options_button');
+    const options_button = document.getElementById('options_button');
     if (options_button) {
         options_button.addEventListener('click', () => {
             if (chrome.runtime.openOptionsPage) {
@@ -93,7 +93,7 @@ function updateHuntTimerField(tab, huntTimerField) {
  * @param {string} message The message to display
  */
 function displayErrorPopup(message) {
-    let error_popup = document.getElementById('error_popup');
+    const error_popup = document.getElementById('error_popup');
     error_popup.innerText = message;
     error_popup.style.display = 'block';
     setTimeout(() => error_popup.style.display = 'none', 2000);

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -1,14 +1,14 @@
 // JS script available only within the pop-up html pages (popup.html & popup2.html)
 /**
  * Query the open tabs and locate the MH tabs. Passes the first result to the callback, along with the invoking button.
- * @param {string} button_pressed the HTML id of the pressed button, to be forwarded to callback
  * @param {Function} callback A function that expects the MH page's tab ID and possibly the button that invoked the call
+ * @param {string} [button_id] the HTML id of the pressed button, to be forwarded to callback
  * @param {boolean} [silent] if true, errors will not be displayed to the user.
  */
-function findOpenMHTab(button_pressed, callback, silent) {
+function findOpenMHTab(callback, button_id, silent) {
     chrome.tabs.query({'url': ['*://www.mousehuntgame.com/*', '*://apps.facebook.com/mousehunt/*']}, tabs => {
         if (tabs.length > 0) {
-            callback(tabs[0].id, button_pressed);
+            callback(tabs[0].id, button_id);
         }
         else if (!silent) {
             displayErrorPopup("Please navigate to MouseHunt page first.");
@@ -20,17 +20,17 @@ function findOpenMHTab(button_pressed, callback, silent) {
  * Forward the pressed button to the content script on the identified tab.
  * (Horn button clicks also activate the MH page.)
  * @param {number} tab_id The tab ID of the MH page
- * @param {string} button_pressed The HTML element ID of the button that was clicked
+ * @param {string} button_id The HTML element ID of the button that was clicked
  */
-function sendMessageToScript(tab_id, button_pressed) {
+function sendMessageToScript(tab_id, button_id) {
     // Switch to MH tab if needed.
     let needsMHPageActive = ['horn', 'tsitu_loader', 'mhmh', 'ryonn'];
-    if (needsMHPageActive.includes(button_pressed)) {
+    if (needsMHPageActive.includes(button_id)) {
         chrome.tabs.update(tab_id, {'active': true});
     }
 
     // Send message to content script
-    chrome.tabs.sendMessage(tab_id, {jacks_link: button_pressed});
+    chrome.tabs.sendMessage(tab_id, {jacks_link: button_id});
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -38,13 +38,13 @@ document.addEventListener('DOMContentLoaded', () => {
     if (version_element) {
         version_element.innerText = ' v' + chrome.runtime.getManifest().version;
     }
-    findOpenMHTab("huntTimer", updateHuntTimer, true);
+    findOpenMHTab(updateHuntTimer, "huntTimer", true);
 
     // Send specific clicks to the content script for handling and/or additional forwarding.
     ['mhmh', 'userhistory', 'ryonn', 'horn', 'tsitu_loader'].forEach(id => {
         let button_element = document.getElementById(id);
         if (button_element) {
-            button_element.addEventListener('click', () => findOpenMHTab(id, sendMessageToScript));
+            button_element.addEventListener('click', () => findOpenMHTab(sendMessageToScript, id));
         }
     });
 });


### PR DESCRIPTION
- Adds JSDoc, updated comments
- Activates MH tab for linked tools that use it or display pop-ups on it (map helpers, Tsitu tools)
- Reorder/update `findOpenMHTab` arguments
- Move standalone functions used only once to point-of-use definitions
- Add check for `chrome.runtime.lastError`, which is emitted by async functions (i.e. `sendMessage`).
  - If the target tab can't/doesn't respond, e.g. the MH tab was removed, reloaded, etc, show this message