### PR TITLE
Stage fixups for Gnawnian Express Station

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1196,7 +1196,17 @@
                     message.stage = "2. Raider River";
                     break;
                 case "bridge_jump":
-                    message.stage = "3. Daredevil Canyon";
+                    let stage = "3. Daredevil Canyon";
+                    if (message.charm) {
+                        if (message.charm.id === 1208) {
+                            stage += " - Dusty Coal";
+                        } else if (message.charm.id === 1207) {
+                            stage += " - Black Powder";
+                        } else if (message.charm.id === 1209) {
+                            stage += " - Magmatic Crystal";
+                        }
+                    }
+                    message.stage = stage;
                     break;
             }
         } else {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1175,7 +1175,7 @@
     }
 
     function getTrainStage(message, response, journal) {
-        let quest = response.user.quests.QuestTrainStation;
+        const quest = response.user.quests.QuestTrainStation;
         if (quest.on_train) {
             switch (quest.current_phase) {
                 case "supplies":
@@ -1193,18 +1193,33 @@
                     message.stage = stage;
                     break;
                 case "boarding":
-                    message.stage = "2. Raider River";
+                    let stage = "2. Raider River";
+                    if (quest.minigame && quest.minigame.trouble_area) {
+                        const charm_id = message.charm.id;
+                        const troubleArea = {
+                            "door": 1210,
+                            "rails": 1211,
+                            "roof": 1212
+                        };
+                        if (troubleArea[quest.minigame.trouble_area] === charm_id) {
+                            stage += " - Defending Target";
+                        } else if ([1210, 1211, 1212].includes(charm_id)) {
+                            stage += " - Defending Other";
+                        } else {
+                            stage += " - Not Defending";
+                        }
+                    }
+                    message.stage = stage;
                     break;
                 case "bridge_jump":
                     let stage = "3. Daredevil Canyon";
-                    if (message.charm) {
-                        if (message.charm.id === 1208) {
-                            stage += " - Dusty Coal";
-                        } else if (message.charm.id === 1207) {
-                            stage += " - Black Powder";
-                        } else if (message.charm.id === 1209) {
-                            stage += " - Magmatic Crystal";
-                        }
+                    const charm_id = message.charm.id;
+                    if (charm_id === 1208) {
+                        stage += " - Dusty Coal";
+                    } else if (charm_id === 1207) {
+                        stage += " - Black Powder";
+                    } else if (charm_id === 1209) {
+                        stage += " - Magmatic Crystal";
                     }
                     message.stage = stage;
                     break;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1176,10 +1176,13 @@
 
     function getTrainStage(message, response, journal) {
         const quest = response.user.quests.QuestTrainStation;
-        if (quest.on_train) {
+        if (!quest.on_train || quest.on_train === "false") {
+            message.stage = "Station";
+        } else {
+            let stage = "";
             switch (quest.current_phase) {
                 case "supplies":
-                    let stage = "1. Supply Depot";
+                    stage = "1. Supply Depot";
                     // If we just caught a Supply Hoarder, or have some hoarder turns remaining,
                     // then a 'Supply Rush' must have been active for this hunt.
                     if (message.mouse === "Supply Hoarder" ||
@@ -1190,10 +1193,9 @@
                         // entry inspection to increase certainty.
                         stage += " - No Rush";
                     }
-                    message.stage = stage;
                     break;
                 case "boarding":
-                    let stage = "2. Raider River";
+                    stage = "2. Raider River";
                     if (quest.minigame && quest.minigame.trouble_area) {
                         const charm_id = message.charm.id;
                         const troubleArea = {
@@ -1209,10 +1211,9 @@
                             stage += " - Not Defending";
                         }
                     }
-                    message.stage = stage;
                     break;
                 case "bridge_jump":
-                    let stage = "3. Daredevil Canyon";
+                    stage = "3. Daredevil Canyon";
                     const charm_id = message.charm.id;
                     if (charm_id === 1208) {
                         stage += " - Dusty Coal";
@@ -1221,11 +1222,11 @@
                     } else if (charm_id === 1209) {
                         stage += " - Magmatic Crystal";
                     }
-                    message.stage = stage;
                     break;
             }
-        } else {
-            message.stage = "Station";
+            if (stage) {
+                message.stage = stage;
+            }
         }
 
         return message;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1177,23 +1177,27 @@
     function getTrainStage(message, response, journal) {
         let quest = response.user.quests.QuestTrainStation;
         if (quest.on_train) {
-            switch (quest.phase_name) {
-                case "Supply Depot":
-                    message.stage = "1. Supply Depot";
+            switch (quest.current_phase) {
+                case "supplies":
+                    let stage = "1. Supply Depot";
+                    // If we just caught a Supply Hoarder, or have some hoarder turns remaining,
+                    // then a 'Supply Rush' must have been active for this hunt.
+                    if (message.mouse === "Supply Hoarder" ||
+                            quest.minigame && quest.minigame.supply_hoarder_turns > 0) {
+                        stage += " - Rush";
+                    } else {
+                        // It's possible the rush ended on this hunt. Need pre-hunt info, or journal
+                        // entry inspection to increase certainty.
+                        stage += " - No Rush";
+                    }
+                    message.stage = stage;
                     break;
-                case "Raider River":
+                case "boarding":
                     message.stage = "2. Raider River";
                     break;
-                case "Daredevil Canyon":
+                case "bridge_jump":
                     message.stage = "3. Daredevil Canyon";
                     break;
-            }
-
-            if (quest.minigame && quest.minigame.supply_hoarder_turns > 0) {
-                // More than 0 (aka 1-5) Hoarder turns means a Supply Rush is active
-                message.stage += " - Rush";
-            } else {
-                message.stage += " - No Rush";
             }
         } else {
             message.stage = "Station";


### PR DESCRIPTION
Rush/No Rush should only be relevant for the Supply Depot phase.

Changes

 - Use the internal minigame phase variables (`supplies`, `boarding`, `bridge_jump`), rather than the names (HG may someday localize and the name is likely subject to localization since it appears in the HUD, while the internal class property is unlikely to be language-dependent.)
 - Use HG charm ID (`trinket_item_id`) rather than the display name, for the same reason.
 - Add stage values for Raider River and Daredevil Canyon that depend on the equipped charm and environment
   - Raider River:
      - "Defending Target": player has the correct charm armed for the current `trouble_area`
      - "Defending Other": player has the incorrect charm armed, but it is one of the special GES Raider River charms
      - "Not Defending": player has any other charm armed

I'm flexible on the names for the Raider River stages. It may not even be relevant to track the "Defending Other" stage, so in the future after some analysis it may be removable.

Example `quest` JSON:

<details><summary>Supply Depot, no rush</summary>

```
"QuestTrainStation":{
...
 "status":"active",
 "seconds_remaining":57206,
 "environment_id":{
       "44":"44"
 },
 "has_error":false,
 "phase_name":"Supply Depot",
 "phase_seconds_remaining":18806,
 "current_phase":"supplies",
 "phases":{
   "supplies":{"global":0,"team":0,"goal":11},
   "boarding":{"global":0,"team":0,"goal":11},
   "bridge_jump":{"global":0,"team":0,"goal":11}
 },
 "minigame":{
   "phase":"supplies",
   "name":"Supply Depot",
   "trinket":"unstable_trinket",
   "supply_hoarder_turns":0,
   "supply_crates":"4",
   "trinkets":{
     "book_warmer_trinket":"39"
   }
 }
...
```
</details>
<details><summary>Raider River -- Roof</summary>

```
 "current_phase": "boarding",
 "minigame":{
   "phase":"boarding",
   "name":"Raider River",
   "trinket":"trouble_area_roof_trinket",
   "raiders_left":10,
   "raiders_total":10,
   "trouble_area":"roof",
   "wave":1,
   "mouse_repellent":"3",
   "trinkets":{
     "trouble_area_roof_trinket":28,
     "trouble_area_door_trinket":"31",
     "trouble_area_rails_trinket":36
   }
 }
```
</details>
<details><summary>Raider River -- Door</summary>

```
"minigame":{
  "phase":"boarding",
  "name":"Raider River",
  "trinket":"soap_trinket",
  "raiders_left":7,
  "raiders_total":10,
  "trouble_area":"door",
  "wave":1,
  "mouse_repellent":"0",
  "trinkets":{
    "trouble_area_roof_trinket":"28",
    "trouble_area_door_trinket":"31",
    "trouble_area_rails_trinket":"36"
  }
}
```
</details>
<details><summary>Raider River -- Rails</summary>

```
"minigame":{
  "phase":"boarding",
  "name":"Raider River",
  "trinket":"soap_trinket",
  "raiders_left":7,
  "raiders_total":10,
  "trouble_area":"rails",
  "wave":1,
  "mouse_repellent":"0",
  "trinkets":{
    "trouble_area_roof_trinket":"28",
    "trouble_area_door_trinket":"31",
    "trouble_area_rails_trinket":"36"
  }
}
```
</details>
<details><summary>Daredevil Canyon</summary>

```
...
"current_phase":"bridge_jump",
"points":7,
"total_goal":32,
"team_goal":32,
"phases":{
  "supplies":{"global":4, "team":"4", "goal":11},
  "boarding":{"global":3, "team":"3", "goal":11},
  "bridge_jump":{"global":0, "team":0, "goal":11}
},
"minigame":{
  "phase":"bridge_jump",
  "name":"Daredevil Canyon",
  "trinket":"train_magmatic_crystal_trinket",
  "fuel_nuggets":4,
  "boost_amount":4,
  "trinkets":{
    "train_coal_trinket":"21",
    "train_black_powder_trinket":"59",
    "train_magmatic_crystal_trinket":48
  }
}
```
</details>