### PR TITLE
Capture stage for MH Birthday 2019

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1256,12 +1256,12 @@
         const quest = response.user.quests.QuestBirthday2019;
         if (message.mouse === "Vincent, The Magnificent" || quest.factory_atts.boss_warning) {
             message.stage = "Boss";
-        } else {
+        } else if (quest.items.coggy_colby_cheese.status === "active") {
             message.stage = (({
-                "pumping_room":           "Pump",
-                "mixing_room":            "Mixing",
-                "break_room":             "Break",
-                "quality_assurance_room": "QA"
+                "pumping_room":           "Pump Room",
+                "mixing_room":            "Mixing Room",
+                "break_room":             "Break Room",
+                "quality_assurance_room": "QA Room"
             })[quest.factory_atts.current_room]);
             if (!message.stage) {
                 return "";

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -753,8 +753,8 @@
             case "Zokor":
                 message = getZokorStage(message, response, journal);
                 break;
-            case "Mysterious Anomaly":
-                message = getMysteriousAnomalyStage(message, response, journal);
+            case "SUPER|brie+ Factory":
+                message = getSBFactoryStage(message, response, journal);
                 break;
         }
 
@@ -1252,8 +1252,21 @@
         return message;
     }
 
-    function getMysteriousAnomalyStage(message, response, journal) {
-        message.stage = response.user.quests.QuestBirthday2018.current_year;
+    function getSBFactoryStage(message, response, journal) {
+        const quest = response.user.quests.QuestBirthday2019;
+        if (message.mouse === "Vincent, The Magnificent" || quest.factory_atts.boss_warning) {
+            message.stage = "Boss";
+        } else {
+            message.stage = (({
+                "pumping_room":           "Pump",
+                "mixing_room":            "Mixing",
+                "break_room":             "Break",
+                "quality_assurance_room": "QA"
+            })[quest.factory_atts.current_room]);
+            if (!message.stage) {
+                return "";
+            }
+        }
 
         return message;
     }
@@ -1265,9 +1278,6 @@
         switch (response.user.location) {
             case "Bristle Woods Rift":
                 message = getBristleWoodsRiftHuntDetails(message, response, journal);
-                break;
-            case "Mysterious Anomaly":
-                message = getMysteriousAnomalyHuntDetails(message, response, journal);
                 break;
         }
 
@@ -1289,16 +1299,6 @@
             message.hunt_details.obelisk_charged = quest.obelisk_percent === 100;
             message.hunt_details.acolyte_sand_drained = message.hunt_details.obelisk_charged && quest.acolyte_sand === 0;
         }
-
-        return message;
-    }
-
-    function getMysteriousAnomalyHuntDetails(message, response, journal) {
-        let quest = response.user.quests.QuestBirthday2018;
-        message.hunt_details = {
-            boss_status: quest.boss_status,
-            furthest_year: quest.furthest_year
-        };
 
         return message;
     }


### PR DESCRIPTION
 - Remove "Mysterious Anomaly" code as it is no longer relevant.

This implementation drops all birthday location hunts not done in one of the 4 rooms.
It's possible we should perform a "cheese check" since the location details / Larry tip strongly suggests that the stage only matters when `quest.items.coggy_colby_cheese.status === "active"` is true (i.e. non event cheese shares same pool, excepting SB+'s extra mouse.

I have the associated methods available for after prehunt goes live but won't add that until required via merge conflict.