### PR TITLE
Fixed inconsistent Auto-Loader bookmarklet injection

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -27,23 +27,24 @@ document.body.appendChild(mhhh_flash_message_div);
 // Inject main script
 const s = document.createElement('script');
 s.src = chrome.extension.getURL('scripts/main.js');
-s.onload = () => s.remove();
 (document.head || document.documentElement).appendChild(s);
-
-// Display Tsitu's Loader
-chrome.storage.sync.get({
-    tsitu_loader_on: false,
-    tsitu_loader_offset: 80
-}, items => {
-    if (items.tsitu_loader_on) {
-        // There must be a better way of doing this
-        window.postMessage({
-            "jacks_message": 'tsitu_loader',
-            "tsitu_loader_offset": items.tsitu_loader_offset,
-            "file_link": chrome.runtime.getURL('third_party/tsitus/bookmarkletloader')
-        }, "*");
-    }
-});
+s.onload = () => {
+    // Display Tsitu's Loader
+    chrome.storage.sync.get({
+        tsitu_loader_on: false,
+        tsitu_loader_offset: 80
+    }, items => {
+        if (items.tsitu_loader_on) {
+            // There must be a better way of doing this
+            window.postMessage({
+                "jacks_message": 'tsitu_loader',
+                "tsitu_loader_offset": items.tsitu_loader_offset,
+                "file_link": chrome.runtime.getURL('third_party/tsitus/bookmarkletloader')
+            }, "*");
+        }
+    });
+    s.remove();
+}
 
 // Handles messages from popup
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {


### PR DESCRIPTION
Moved "Display Tsitu's Loader" logic inside the load event handler for `main.js` to prevent it from running before `main.js` is executed, which leaves the message event unhandled.