### PR TITLE
Switch to "no-cors" request to enable crown submissions from FF

### DIFF
--- a/scripts/background.js
+++ b/scripts/background.js
@@ -145,8 +145,9 @@ function icon_timer_updateBadge(tab_id, settings) {
                     if (response_int > 59) {
                         let minutes = Math.floor(response_int / 100);
                         const seconds = response_int % 100;
-                        if (seconds > 30)
+                        if (seconds > 30) {
                             ++minutes;
+                        }
                         response = minutes + 'm';
                     } else {
                         response = response_int + 's';
@@ -159,3 +160,18 @@ function icon_timer_updateBadge(tab_id, settings) {
         }
     });
 }
+
+// Handle messages sent by the extension to the runtime.
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+    // Check the message for something to log in the background's console.
+    if (msg.log) {
+        let fn = console.log;
+        if (msg.is_error) {
+            fn = console.error;
+        } else if (msg.is_warning) {
+            fn = console.warn;
+        }
+        fn({message: msg.log, sender});
+    }
+    // TODO: Handle other aspects of the extension message.
+});


### PR DESCRIPTION
Refs DevJackSmith/mh-hunt-helper#98

I was unable to resolve the NetworkError with either `window.fetch`, `XMLHttpRequest`, adding `"*://script.google.com/*"` and `"webRequest"` to the extension manifests' `permissions`, and combinations thereof. 

I verified that, in `"no-cors"` mode, both Firefox and Chrome do actually make the submission to the Apps Script endpoint with my normal privacy-focused extensions both disabled and enabled, so I think this is OK.

I'm open to some other solution that makes it possible to know whether the request was even issued, but until then we'll have to settle for blind-firing the request. If we eventually add a way to query the user's crown history, then we could test via that method whether a new crown snapshot was recorded while still maintaining the "no-cors" submission request.


This PR also adds a background script listener for warning, log, or error messages coming from the extension. Previously there was no way to log anything on the background console, which is persistent across page reloads (unlike the default browser console).