### PR TITLE
Track WWR rage levels for Lactrodectus usage

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1473,7 +1473,7 @@
     }
 
     /**
-     * For MBW attractions, record the rage state of each zone.
+     * For Lactrodectus hunts, if MBW can be attracted (and is not guaranteed), record the rage state.
      * @param {Object <string, any>} message The message to be sent.
      * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
      * @param {Object <string, any>} user_post The user state object, after the hunt.
@@ -1487,10 +1487,12 @@
                 tree: parseInt(zones.tree.level, 10),
                 lagoon: parseInt(zones.lagoon.level, 10)
             };
-            message.hunt_details = Object.assign(rage, {
-                total_rage: rage.clearing + rage.tree + rage.lagoon,
-                can_attract_mbw: (rage.clearing > 24 && rage.tree > 24 && rage.lagoon > 24)
-            });
+            const total_rage = rage.clearing + rage.tree + rage.lagoon;
+            if (total_rage < 150 && total_rage >= 75) {
+                if (rage.clearing > 24 && rage.tree > 24 && rage.lagoon > 24) {
+                    message.hunt_details = Object.assign(rage, {total_rage});
+                }
+            }
         }
     }
 

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1368,6 +1368,7 @@
     const location_huntdetails_lookup = {
         "Bristle Woods Rift": addBristleWoodsRiftHuntDetails,
         "Sand Crypts": addSandCryptsHuntDetails,
+        "Whisker Woods Rift": addWhiskerWoodsRiftHuntDetails,
         "Zugzwang's Tower": addZugzwangsTowerHuntDetails
     };
 
@@ -1468,6 +1469,28 @@
                     salt: quest.minigame.salt_charms_used
                 };
             }
+        }
+    }
+
+    /**
+     * For MBW attractions, record the rage state of each zone.
+     * @param {Object <string, any>} message The message to be sent.
+     * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
+     * @param {Object <string, any>} user_post The user state object, after the hunt.
+     * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
+     */
+    function addWhiskerWoodsRiftHuntDetails(message, user, user_post, hunt) {
+        if (message.cheese.id === 1646) {
+            const zones = user.quests.QuestRiftWhiskerWoods.zones;
+            const rage = {
+                clearing: parseInt(zones.clearing.level, 10),
+                tree: parseInt(zones.tree.level, 10),
+                lagoon: parseInt(zones.lagoon.level, 10)
+            };
+            message.hunt_details = Object.assign(rage, {
+                total_rage: rage.clearing + rage.tree + rage.lagoon,
+                can_attract_mbw: (rage.clearing > 24 && rage.tree > 24 && rage.lagoon > 24)
+            });
         }
     }
 


### PR DESCRIPTION
The current WWR stage information is a string-based categorical variable for the 3 rage states. This PR adds a numerical value for each level, a true/false boolean for whether the attraction criteria is met (all >= 25), and the total rage sum.

It's possible the sum and boolean are unnecessary, as that information can conceivably be derived from the numerical levels in a SQL query.

I don't think knowing the numeric levels is important for other cheeses, which is why the cheese check is performed.