### PR TITLE
Track Zokor mouse demoralization & Minotaur state

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1368,6 +1368,7 @@
     const location_huntdetails_lookup = {
         "Bristle Woods Rift": addBristleWoodsRiftHuntDetails,
         "Sand Crypts": addSandCryptsHuntDetails,
+        "Zokor": addZokorHuntDetails,
         "Zugzwang's Tower": addZugzwangsTowerHuntDetails
     };
 
@@ -1469,6 +1470,24 @@
                 };
             }
         }
+    }
+
+    /**
+     * For the level-3 districts, report whether the boss was defeated or not.
+     * @param {Object <string, any>} message The message to be sent.
+     * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
+     * @param {Object <string, any>} user_post The user state object, after the hunt.
+     * @param {Object <string, any>} hunt The journal entry corresponding to the active hunt.
+     */
+    function addZokorHuntDetails(message, user, user_post, hunt) {
+        const quest = user.quests.QuestAncientCity;
+        if (quest.district_tier === 3 && quest.clue_type) {
+            // TODO: Verify that Mino Lair does not enter this branch
+            message.hunt_details = {
+                boss_defeated: (quest.boss === "defeated"),
+            };
+        }
+        // TODO: Minotaur rage state
     }
 
     /**

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1474,6 +1474,7 @@
 
     /**
      * For the level-3 districts, report whether the boss was defeated or not.
+     * For the Minotaur lair, report the categorical label, number of catches, and meter width.
      * @param {Object <string, any>} message The message to be sent.
      * @param {Object <string, any>} user The user state object, when the hunt was invoked (pre-hunt).
      * @param {Object <string, any>} user_post The user state object, after the hunt.
@@ -1481,13 +1482,17 @@
      */
     function addZokorHuntDetails(message, user, user_post, hunt) {
         const quest = user.quests.QuestAncientCity;
-        if (quest.district_tier === 3 && quest.clue_type) {
-            // TODO: Verify that Mino Lair does not enter this branch
+        if (quest.boss.includes("hiddenDistrict")) {
+            message.hunt_details = {
+                minotaur_label: quest.boss.replace(/hiddenDistrict/i, "").trim(),
+                lair_catches: -(quest.countdown - 20),
+                minotaur_meter: parseFloat(quest.width)
+            };
+        } else if (quest.district_tier === 3) {
             message.hunt_details = {
                 boss_defeated: (quest.boss === "defeated"),
             };
         }
-        // TODO: Minotaur rage state
     }
 
     /**


### PR DESCRIPTION
Checks the boss state and flags associated hunts. For the Minotaur Lair, tracks the number of catches made so far, the categorical label, and the rage bar width.