### PR TITLE
Remove deprecated update checks

### DIFF
--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -9,19 +9,6 @@ chrome.runtime.onUpdateAvailable.addListener(details => {
     chrome.runtime.reload();
 });
 
-// TODO: Do we need to request the update at all? Chrome auto-checks automatically.
-const time_interval = 7200 * 1000; // seconds * 1000
-window.setInterval(() => chrome.runtime.requestUpdateCheck(status => {
-        if (status == "update_available") {
-            console.log("MHHH: update pending...");
-        } else if (status == "no_update") {
-            console.log("MHHH: no update found");
-        } else if (status == "throttled") {
-            console.log("MHHH: Oops, update check failed.");
-        }
-    }),
-time_interval);
-
 // Refreshes MH pages when new version is installed, to inject the latest extension code.
 chrome.runtime.onInstalled.addListener(() => chrome.tabs.query(
     {'url': ['*://www.mousehuntgame.com/*', '*://apps.facebook.com/mousehunt/*']},


### PR DESCRIPTION
 - Chrome explicitly notifies the extension when updates are available - no checking needed.
 - Firefox has no browser support for the [`runtime.requestUpdateCheck` method](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/requestUpdateCheck)
 - Firefox also [auto-updates AMO-hosted extensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Distribution#Distributing_your_add-on)
 - Opera behavior is probably like Chrome, but doesn't really warrant any consideration anymore since their  update approval rate is slower than global warming